### PR TITLE
Use Absolute Path for configure Command

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -44,7 +44,7 @@ fn main() {
         if !dest.join("lib").exists() {
             eprintln!("building gdbm, dest = {}", dest.display());
             assert!(
-                Command::new("./configure")
+                Command::new(src_dir.join("configure"))
                 .arg("--without-readline")
                 .arg(&format!("--prefix={}", dest.display()))
                 .current_dir(&src_dir)


### PR DESCRIPTION
The documentation for [std::process::Command::current_dir](https://doc.rust-lang.org/std/process/struct.Command.html#method.current_dir) warns that whether the program path is relative to the parent process' working directory or the one given to `current_dir` is platform-dependent. This, in fact, causes the build to fail on MacOS. The simple fix is to use an absolute path to run the `configure` script.