### PR TITLE
Implement std::error::Error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -115,6 +115,8 @@ impl fmt::Display for Error {
     }
 }
 
+impl std::error::Error for Error {}
+
 #[doc(hidden)]
 impl From<u32> for Error {
     fn from(src: u32) -> Error {


### PR DESCRIPTION
A simple mark can make it compatible with anyhow.